### PR TITLE
[fix] GlobalStyles.tsx의 textEllipsis가 파이어폭스에서도 작동이 되게 수정 

### DIFF
--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -126,6 +126,28 @@ export const textEllipsis = (lineClamp: number) => css`
   -webkit-box-orient: vertical;
   text-overflow: ellipsis;
   overflow: hidden;
+  &::before {
+    content: '...';
+    position: absolute;
+    right: 0;
+    bottom: 0;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    width: 1em;
+    height: 1em;
+    background: white;
+  }
+
+  @supports (-webkit-line-clamp: ${lineClamp}) {
+    &::before,
+    &::after {
+      display: none;
+    }
+  }
 `;
 
 export default GlobalStyles;


### PR DESCRIPTION
- &::before, &::after 를 이용해서 줄이 많아지면 줄임표 생략을 하게함.
- 일정 줄 이하가 아니라 높이나 칸 크기룰 초과할 경우에 줄임표가 붙여서 텍스트를 생략함.
```
export const textEllipsis = (lineClamp: number) => css`
  display: -webkit-box;
  -webkit-line-clamp: ${lineClamp};
  -webkit-box-orient: vertical;
  text-overflow: ellipsis;
  overflow: hidden;

  &::before {
    content: '...';
    position: absolute;
    right: 0;
    bottom: 0;
  }

  &::after {
    content: '';
    position: absolute;
    right: 0;
    width: 1em;
    height: 1em;
    background: white;
  }

  @supports (-webkit-line-clamp: ${lineClamp}) {
    &::before,
    &::after {
      display: none;
    }
  }
`;
```
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- **New Feature**: 텍스트 생략 기능 개선 - `textEllipsis` 함수에 &::before 및 &::after 스타일 속성을 추가하여 텍스트 생략 시 더 나은 사용자 경험 제공.
- **Refactor**: @supports 미디어 쿼리를 사용하여 특정 조건에서 &::before와 &::after가 숨겨지도록 변경, 스타일 적용의 유연성 향상.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->