### PR TITLE
[Enhancement] 팔로우 페이지 기능 및 스타일 수정

### DIFF
--- a/src/api/fetchPosts.ts
+++ b/src/api/fetchPosts.ts
@@ -22,7 +22,7 @@ export const getPostByPostId = async ({ postId }: { postId: string }): Promise<P
   return { postId: postDocSnapshot.id, ...postDocSnapshot.data() } as PostModel;
 };
 
-export const getPostsFilterdLikes = async ({
+export const getPostsFilteredLikes = async ({
   userId,
   count = 10,
   lastPostId,

--- a/src/components/common/loading/Loading.tsx
+++ b/src/components/common/loading/Loading.tsx
@@ -2,6 +2,7 @@ import { css, keyframes } from '@emotion/react';
 
 import logo from '@/assets/images/logo.svg';
 import { mainStyle } from '@/layouts/Container';
+import theme from '@/styles/theme';
 
 const Loading = () => {
   return (
@@ -25,6 +26,10 @@ const containerStyle = css`
   flex-direction: column;
   align-items: center;
   gap: 24px;
+
+  @media screen and (min-width: ${theme.width.max}) {
+    border: 0;
+  }
 
   img {
     width: 70px;

--- a/src/components/profile/ProfileInfo.tsx
+++ b/src/components/profile/ProfileInfo.tsx
@@ -59,13 +59,13 @@ const ProfileInfo: React.FC<ProfileInfoProps> = ({
             <p css={usernameStyle}>{userData.displayName}</p>
             <div css={followInfoStyle}>
               <Link
-                to={`/profile/${profileUserId}/follow?following=${userData?.following?.length || 0}&followers=${userData?.followers?.length || 0}`}
+                to={`/profile/${profileUserId}/follow?following=${userData?.following?.length || 0}&followers=${userData?.followers?.length || 0}&active=following`}
               >
                 <span css={followCountStyle}>{userData?.following?.length || 0}</span>
                 <span css={followLabelStyle}>팔로잉</span>
               </Link>
               <Link
-                to={`/profile/${profileUserId}/follow?following=${userData?.following?.length || 0}&followers=${userData?.followers?.length || 0}`}
+                to={`/profile/${profileUserId}/follow?following=${userData?.following?.length || 0}&followers=${userData?.followers?.length || 0}&active=followers`}
               >
                 <span css={followCountStyle}>{userData?.followers?.length || 0}</span>
                 <span css={followLabelStyle}>팔로워</span>

--- a/src/components/user/UserInfo.tsx
+++ b/src/components/user/UserInfo.tsx
@@ -61,6 +61,7 @@ const UserInfo: React.FC<UserInfoProps> = ({
           onClick={() => {
             onFollowToggle(userId);
           }}
+          customStyle={buttonStyle}
         >
           {isFollowing ? '팔로잉' : '팔로우'}
         </FitButton>
@@ -132,6 +133,10 @@ const userInfoStyle = (imageSize: ImageSizeType) => css`
       }
     }
   }
+`;
+
+const buttonStyle = css`
+  font-weight: 600;
 `;
 
 export default UserInfo;

--- a/src/pages/Follow.tsx
+++ b/src/pages/Follow.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState, useMemo } from 'react';
 
 import { css } from '@emotion/react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 
 import TabContent from '@/components/common/tabs/TabContent';
 import TabMenu from '@/components/common/tabs/TabMenu';
@@ -13,11 +13,14 @@ import { UserData } from '@/types/profile';
 
 const FollowPage = () => {
   const { userId } = useParams<{ userId: string }>();
+  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { userData, followingUsers, followerUsers, toggleFollow, isFollowing } = useUserData(
     userId || null,
   );
-  const [activeTab, setActiveTab] = useState('following');
+
+  const initialActiveTab = searchParams.get('active') || 'following';
+  const [activeTab, setActiveTab] = useState(initialActiveTab);
   const currentUser = useAuth();
 
   const handleFollowToggle = useCallback(

--- a/src/pages/Follow.tsx
+++ b/src/pages/Follow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import { css } from '@emotion/react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
@@ -8,6 +8,7 @@ import TabMenu from '@/components/common/tabs/TabMenu';
 import BackHeader from '@/components/layout/header/BackHeader';
 import UserInfo from '@/components/user/UserInfo';
 import { useAuth } from '@/hooks/useAuth';
+import { useDebounce } from '@/hooks/useDebounce';
 import { useUserData } from '@/hooks/useUserData';
 import { UserData } from '@/types/profile';
 
@@ -15,13 +16,22 @@ const FollowPage: React.FC = () => {
   const { userId } = useParams<{ userId: string }>();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
-  const { userData, followingUsers, followerUsers, toggleFollow, isFollowing } = useUserData(
-    userId || null,
-  );
+  const { userData, followingUsers, followerUsers, toggleFollow, isFollowing, refetchUserData } =
+    useUserData(userId || null);
   const currentUser = useAuth();
 
   const initialActiveTab = searchParams.get('active') || 'following';
-  const [activeTab, setActiveTab] = useState(initialActiveTab);
+  const {
+    value: activeTab,
+    debouncedValue: debouncedActiveTab,
+    onChange: setActiveTab,
+  } = useDebounce({
+    initialValue: initialActiveTab,
+  });
+
+  useEffect(() => {
+    refetchUserData();
+  }, [debouncedActiveTab, refetchUserData]);
 
   const handleFollowToggle = useCallback(
     async (targetUserId: string) => {

--- a/src/pages/Follow.tsx
+++ b/src/pages/Follow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useMemo } from 'react';
+import { useCallback, useState } from 'react';
 
 import { css } from '@emotion/react';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
@@ -11,17 +11,17 @@ import { useAuth } from '@/hooks/useAuth';
 import { useUserData } from '@/hooks/useUserData';
 import { UserData } from '@/types/profile';
 
-const FollowPage = () => {
+const FollowPage: React.FC = () => {
   const { userId } = useParams<{ userId: string }>();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { userData, followingUsers, followerUsers, toggleFollow, isFollowing } = useUserData(
     userId || null,
   );
+  const currentUser = useAuth();
 
   const initialActiveTab = searchParams.get('active') || 'following';
   const [activeTab, setActiveTab] = useState(initialActiveTab);
-  const currentUser = useAuth();
 
   const handleFollowToggle = useCallback(
     async (targetUserId: string) => {
@@ -61,13 +61,10 @@ const FollowPage = () => {
     ));
   };
 
-  const tabs = useMemo(
-    () => [
-      { id: 'following', label: `팔로잉 ${followingUsers.length}` },
-      { id: 'followers', label: `팔로워 ${followerUsers.length}` },
-    ],
-    [followingUsers.length, followerUsers.length],
-  );
+  const tabs = [
+    { id: 'following', label: `팔로잉 ${userData?.following?.length || 0}` },
+    { id: 'followers', label: `팔로워 ${userData?.followers?.length || 0}` },
+  ];
 
   return (
     <>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/react';
 import { HiOutlinePencil, HiOutlinePlay, HiOutlineHeart } from 'react-icons/hi2';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { getPostsByUserId, getPostsFilterdLikes } from '@/api/fetchPosts';
+import { getPostsByUserId, getPostsFilteredLikes } from '@/api/fetchPosts';
 import Spinner from '@/components/common/loading/Spinner';
 import TabContent from '@/components/common/tabs/TabContent';
 import TabMenu from '@/components/common/tabs/TabMenu';
@@ -67,7 +67,7 @@ const ProfilePage: React.FC = () => {
       if (userId) {
         try {
           setLoadingLikedPosts(true);
-          const posts = await getPostsFilterdLikes({ userId });
+          const posts = await getPostsFilteredLikes({ userId });
           setLikedPosts(posts);
         } catch (err) {
           setError('Failed to load liked posts');


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- AI에게 리뷰를 받고 싶지 않다면 🤷‍♀️이모지를 제거해주세요. -->
@coderabbitai: i🤷‍♀️gnore

## 📋 작업 내용

- 팔로워를 누르면 팔로워 탭이, 팔로잉을 누르면 팔로잉 탭이 활성화된 상태로 페이지 이동
- 탭의 팔로워/팔로잉 카운트가 바로 업데이트 되도록 수정
- 다른 유저의 팔로우 페이지에서 로그인 한 유저 기준으로 팔로우/팔로잉 버튼이 뜨도록 수정

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
### Release Notes

#### New Feature
- 프로필 페이지에서 팔로우/언팔로우 탭 활성화 및 URL 매개변수 수정.
- `useAuth` 훅 추가 및 현재 사용자의 ID 가져오기 기능 변경.
- `useDebounce` 훅 추가 및 초기 탭 상태 설정.

#### Bug Fix
- 함수명 수정: `getPostsFilterdLikes` -> `getPostsFilteredLikes`.

#### Refactor
- `UserInfo` 컴포넌트에 `customStyle` prop 추가 및 `buttonStyle` CSS 정의.
- `Loading` 컴포넌트에 미디어 쿼리 추가 및 `theme` import.
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->