### PR TITLE
[Enhancement/Design] 포스트 상세 페이지, 타임라인 스타일 수정 및 약간의 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,12 @@ import { PATH } from '@/constants/path';
 import ContainerLayout from '@/layouts/Container';
 import RootLayout from '@/layouts/Root';
 import AddPostPage from '@/pages/AddPost';
-import { Comment } from '@/pages/Comment';
 import FollowPage from '@/pages/Follow';
 import HomePage from '@/pages/Home';
 import NewPost from '@/pages/NewPost';
 import PlaylistPage from '@/pages/Playlist';
 import PlaylistDetailPage from '@/pages/PlaylistDetail';
+import PostDetailPage from '@/pages/PostDetail';
 import PrivacyPolicyPage from '@/pages/PrivacyPolicyPage';
 import ProfilePage from '@/pages/Profile';
 import ProfileEditPage from '@/pages/ProfileEdit';
@@ -99,8 +99,8 @@ const router = createBrowserRouter([
             element: <ProfilePage />,
           },
           {
-            path: PATH.COMMENT,
-            element: <Comment />,
+            path: PATH.POST_DETAIL,
+            element: <PostDetailPage />,
           },
         ],
       },

--- a/src/components/comment/CommentInput.tsx
+++ b/src/components/comment/CommentInput.tsx
@@ -1,23 +1,25 @@
 import { useEffect, useRef } from 'react';
 
-import { css } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
 import { HiOutlinePaperAirplane } from 'react-icons/hi2';
 
 import theme from '@/styles/theme';
 
-const INPUT_MIN_HEIGHT = 44;
+const INPUT_MIN_HEIGHT = 40;
 const INPUT_MAX_HEIGHT = INPUT_MIN_HEIGHT * 2;
 
 interface CommentInputProps {
-  newCommentContent: string;
-  setNewCommentContent: (content: string) => void;
-  handleCreateComment: () => void;
+  comment: string;
+  onChange: (comment: string) => void;
+  onSubmit: () => void;
+  customStyle?: SerializedStyles;
 }
 
 export const CommentInput: React.FC<CommentInputProps> = ({
-  newCommentContent,
-  setNewCommentContent,
-  handleCreateComment,
+  comment,
+  onChange,
+  onSubmit,
+  customStyle,
 }) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -27,26 +29,25 @@ export const CommentInput: React.FC<CommentInputProps> = ({
       textarea.style.height = `${INPUT_MIN_HEIGHT}px`;
       textarea.style.height = `${Math.min(textarea.scrollHeight, INPUT_MAX_HEIGHT)}px`;
     }
-  }, [newCommentContent]);
+  }, [comment]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      handleCreateComment();
+      onSubmit();
     }
   };
 
   return (
-    <div css={newCommentStyle}>
+    <div css={[newCommentStyle, customStyle]}>
       <textarea
         ref={textareaRef}
-        css={textareaStyle}
-        value={newCommentContent}
-        onChange={(e) => setNewCommentContent(e.target.value)}
+        value={comment}
+        onChange={(e) => onChange(e.target.value)}
         onKeyDown={handleKeyDown}
         placeholder="답글을 작성해주세요"
       />
-      <button css={sendButtonStyle} onClick={handleCreateComment}>
+      <button onClick={onSubmit}>
         <HiOutlinePaperAirplane />
       </button>
     </div>
@@ -58,48 +59,34 @@ const newCommentStyle = css`
   align-items: flex-end;
   width: 100%;
   border: 1px solid ${theme.colors.lightGray};
-  border-radius: 16px;
+  border-radius: 12px;
   background-color: ${theme.colors.bgGray};
-`;
 
-const textareaStyle = css`
-  width: 100%;
-  min-height: ${INPUT_MIN_HEIGHT}px;
-  max-height: ${INPUT_MAX_HEIGHT}px;
-  padding: 12px 0 8px 16px;
-  font-size: ${theme.fontSizes.small};
-  background-color: transparent;
-  overflow-y: auto;
-
-  @media screen and (min-width: ${theme.width.large}) {
-    padding: 10px 0 8px 16px;
-    font-size: ${theme.fontSizes.base};
-  }
-`;
-
-const sendButtonStyle = css`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 8px 16px 12px;
-  border: none;
-  border-radius: 4px;
-  color: ${theme.colors.darkestGray};
-  background-color: transparent;
-  align-self: flex-end;
-  cursor: pointer;
-
-  svg {
-    font-size: 20px;
-    transform: rotate(-45deg);
+  textarea {
+    width: 100%;
+    min-height: ${INPUT_MIN_HEIGHT}px;
+    max-height: ${INPUT_MAX_HEIGHT}px;
+    padding: 12px 0 8px 16px;
+    font-size: ${theme.fontSizes.small};
+    background-color: transparent;
+    overflow-y: auto;
   }
 
-  @media screen and (min-width: ${theme.width.large}) {
-    padding: 10px 8px 12px;
-    font-size: ${theme.fontSizes.base};
+  button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 10px 12px;
+    border: none;
+    border-radius: 4px;
+    color: ${theme.colors.darkestGray};
+    background-color: transparent;
+    align-self: flex-end;
+    cursor: pointer;
 
     svg {
-      font-size: 24px;
+      font-size: 20px;
+      transform: rotate(-45deg);
     }
   }
 `;

--- a/src/components/comment/CommentInput.tsx
+++ b/src/components/comment/CommentInput.tsx
@@ -1,7 +1,12 @@
+import { useEffect, useRef } from 'react';
+
 import { css } from '@emotion/react';
 import { HiOutlinePaperAirplane } from 'react-icons/hi2';
 
 import theme from '@/styles/theme';
+
+const INPUT_MIN_HEIGHT = 44;
+const INPUT_MAX_HEIGHT = INPUT_MIN_HEIGHT * 2;
 
 interface CommentInputProps {
   newCommentContent: string;
@@ -14,6 +19,16 @@ export const CommentInput: React.FC<CommentInputProps> = ({
   setNewCommentContent,
   handleCreateComment,
 }) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      textarea.style.height = `${INPUT_MIN_HEIGHT}px`;
+      textarea.style.height = `${Math.min(textarea.scrollHeight, INPUT_MAX_HEIGHT)}px`;
+    }
+  }, [newCommentContent]);
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
@@ -24,11 +39,12 @@ export const CommentInput: React.FC<CommentInputProps> = ({
   return (
     <div css={newCommentStyle}>
       <textarea
+        ref={textareaRef}
         css={textareaStyle}
         value={newCommentContent}
         onChange={(e) => setNewCommentContent(e.target.value)}
         onKeyDown={handleKeyDown}
-        placeholder="댓글을 입력하세요..."
+        placeholder="답글을 작성해주세요"
       />
       <button css={sendButtonStyle} onClick={handleCreateComment}>
         <HiOutlinePaperAirplane />
@@ -39,26 +55,51 @@ export const CommentInput: React.FC<CommentInputProps> = ({
 
 const newCommentStyle = css`
   display: flex;
-  margin-bottom: 20px;
+  align-items: flex-end;
+  width: 100%;
+  border: 1px solid ${theme.colors.lightGray};
+  border-radius: 16px;
+  background-color: ${theme.colors.bgGray};
 `;
 
 const textareaStyle = css`
-  flex: 1;
-  padding: 10px;
-  border: 1px solid ${theme.colors.lightGray};
-  border-radius: 4px;
-  resize: none;
+  width: 100%;
+  min-height: ${INPUT_MIN_HEIGHT}px;
+  max-height: ${INPUT_MAX_HEIGHT}px;
+  padding: 12px 0 8px 16px;
+  font-size: ${theme.fontSizes.small};
+  background-color: transparent;
+  overflow-y: auto;
+
+  @media screen and (min-width: ${theme.width.large}) {
+    padding: 10px 0 8px 16px;
+    font-size: ${theme.fontSizes.base};
+  }
 `;
 
 const sendButtonStyle = css`
-  background: ${theme.colors.primary};
-  border: none;
-  color: white;
-  padding: 10px;
-  border-radius: 4px;
-  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-left: 10px;
+  padding: 8px 16px 12px;
+  border: none;
+  border-radius: 4px;
+  color: ${theme.colors.darkestGray};
+  background-color: transparent;
+  align-self: flex-end;
+  cursor: pointer;
+
+  svg {
+    font-size: 20px;
+    transform: rotate(-45deg);
+  }
+
+  @media screen and (min-width: ${theme.width.large}) {
+    padding: 10px 8px 12px;
+    font-size: ${theme.fontSizes.base};
+
+    svg {
+      font-size: 24px;
+    }
+  }
 `;

--- a/src/components/comment/CommentItem.tsx
+++ b/src/components/comment/CommentItem.tsx
@@ -48,7 +48,7 @@ const CommentItem: React.FC<CommentItemProps> = ({
             <DropdownMenu.Root>
               <DropdownMenu.Trigger asChild>
                 <button css={menuTriggerStyle}>
-                  <HiDotsVertical />
+                  <HiDotsVertical size={18} />
                 </button>
               </DropdownMenu.Trigger>
 
@@ -110,7 +110,6 @@ const commentStyle = css`
   display: flex;
   align-items: flex-start;
   padding: 12px 0;
-  transform: translateX(5px);
 `;
 
 const avatarStyle = css`
@@ -141,7 +140,8 @@ const userInfoStyle = css`
 `;
 
 const nameStyle = css`
-  font-weight: bold;
+  color: ${theme.colors.darkestGray};
+  font-weight: 600;
   margin-right: 8px;
   white-space: nowrap;
   overflow: hidden;
@@ -155,24 +155,25 @@ const timeStyle = css`
 `;
 
 const menuTriggerStyle = css`
-  background: none;
-  border: none;
-  cursor: pointer;
-  padding: 4px;
-  color: ${theme.colors.darkGray};
   flex-shrink: 0;
+  height: 18px;
   margin-left: 8px;
-  &:hover {
-    color: ${theme.colors.black};
-  }
+  border: none;
+  color: ${theme.colors.darkGray};
+  background: none;
+  cursor: pointer;
 `;
 
 const commentTextStyle = css`
-  color: ${theme.colors.darkestGray};
-  line-height: 1.4;
   word-wrap: break-word;
   overflow-wrap: break-word;
-  padding-right: 24px;
+  padding-right: 32px;
+  text-align: justify;
+  font-size: ${theme.fontSizes.small};
+
+  @media screen and (min-width: ${theme.width.large}) {
+    font-size: ${theme.fontSizes.base};
+  }
 `;
 
 const menuContentStyle = css`

--- a/src/components/comment/CommentItem.tsx
+++ b/src/components/comment/CommentItem.tsx
@@ -1,9 +1,11 @@
 import { css } from '@emotion/react';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { HiDotsVertical, HiPencil, HiTrash } from 'react-icons/hi';
+import { HiXMark } from 'react-icons/hi2';
 
 import defaultProfile from '@/assets/images/default-avatar.svg';
-import FullButton from '@/components/common/buttons/FullButton';
+import { CommentInput } from '@/components/comment/CommentInput';
+import FitButton from '@/components/common/buttons/FitButton';
 import theme from '@/styles/theme';
 import { CommentModel } from '@/types/comment';
 import { formatCreatedAt } from '@/utils/date';
@@ -75,29 +77,21 @@ const CommentItem: React.FC<CommentItemProps> = ({
           )}
         </div>
         {editingCommentId === comment.id ? (
-          <>
-            <textarea
-              css={editTextareaStyle}
-              value={editingContent}
-              onChange={(e) => setEditingContent(e.target.value)}
+          <div css={editCommentContainerStyle}>
+            <CommentInput
+              comment={editingContent}
+              onChange={setEditingContent}
+              onSubmit={() => handleUpdateComment(comment.id)}
+              customStyle={editInputStyle}
             />
-            <div css={editButtonsStyle}>
-              <FullButton
-                styleType="primary"
-                customStyle={smallerButtonStyle}
-                onClick={() => handleUpdateComment(comment.id)}
-              >
-                저장
-              </FullButton>
-              <FullButton
-                styleType="disabled"
-                customStyle={smallerButtonStyle}
-                onClick={() => setEditingCommentId(null)}
-              >
-                취소
-              </FullButton>
-            </div>
-          </>
+            <FitButton
+              styleType="secondary"
+              onClick={() => setEditingCommentId(null)}
+              customStyle={cancelButtonStyle}
+            >
+              <HiXMark size={20} />
+            </FitButton>
+          </div>
         ) : (
           <p css={commentTextStyle}>{comment.content}</p>
         )}
@@ -109,14 +103,14 @@ const CommentItem: React.FC<CommentItemProps> = ({
 const commentStyle = css`
   display: flex;
   align-items: flex-start;
-  padding: 12px 0;
+  padding: 8px 0;
 `;
 
 const avatarStyle = css`
-  width: 40px;
-  height: 40px;
+  width: 32px;
+  height: 32px;
   border-radius: 50%;
-  margin-right: 12px;
+  margin-right: 8px;
   flex-shrink: 0;
 `;
 
@@ -136,11 +130,13 @@ const userInfoStyle = css`
   display: flex;
   align-items: center;
   min-width: 0;
+  margin-top: 2px;
   flex: 1;
 `;
 
 const nameStyle = css`
   color: ${theme.colors.darkestGray};
+  font-size: ${theme.fontSizes.small};
   font-weight: 600;
   margin-right: 8px;
   white-space: nowrap;
@@ -150,7 +146,7 @@ const nameStyle = css`
 
 const timeStyle = css`
   color: ${theme.colors.darkGray};
-  font-size: ${theme.fontSizes.small};
+  font-size: ${theme.fontSizes.micro};
   white-space: nowrap;
 `;
 
@@ -170,10 +166,17 @@ const commentTextStyle = css`
   padding-right: 32px;
   text-align: justify;
   font-size: ${theme.fontSizes.small};
+`;
 
-  @media screen and (min-width: ${theme.width.large}) {
-    font-size: ${theme.fontSizes.base};
-  }
+const editCommentContainerStyle = css`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+`;
+
+const editInputStyle = css`
+  background-color: ${theme.colors.white};
 `;
 
 const menuContentStyle = css`
@@ -212,26 +215,20 @@ const menuItemStyle = css`
   }
 `;
 
-const editTextareaStyle = css`
-  width: 100%;
-  padding: 8px;
+const cancelButtonStyle = css`
+  justify-content: center;
+  align-items: center;
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  padding: 0;
   border: 1px solid ${theme.colors.lightGray};
-  border-radius: 4px;
-  font-size: ${theme.fontSizes.small};
-  resize: vertical;
-  margin-bottom: 8px;
-`;
+  background-color: ${theme.colors.bgGray};
+  cursor: pointer;
 
-const editButtonsStyle = css`
-  display: flex;
-  gap: 8px;
-`;
-
-const smallerButtonStyle = css`
-  height: 25px;
-  padding: 0 10px;
-  font-size: ${theme.fontSizes.small};
-  width: auto;
+  svg {
+    stroke-width: 0.2;
+  }
 `;
 
 export default CommentItem;

--- a/src/components/comment/CommentItem.tsx
+++ b/src/components/comment/CommentItem.tsx
@@ -2,10 +2,12 @@ import { css } from '@emotion/react';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { HiDotsVertical, HiPencil, HiTrash } from 'react-icons/hi';
 import { HiXMark } from 'react-icons/hi2';
+import { Link } from 'react-router-dom';
 
 import defaultProfile from '@/assets/images/default-avatar.svg';
 import { CommentInput } from '@/components/comment/CommentInput';
 import FitButton from '@/components/common/buttons/FitButton';
+import { PATH } from '@/constants/path';
 import theme from '@/styles/theme';
 import { CommentModel } from '@/types/comment';
 import { formatCreatedAt } from '@/utils/date';
@@ -43,7 +45,9 @@ const CommentItem: React.FC<CommentItemProps> = ({
       <div css={commentContentStyle}>
         <div css={headerStyle}>
           <div css={userInfoStyle}>
-            <span css={nameStyle}>{userData?.displayName || 'Unknown User'}</span>
+            <Link to={PATH.PROFILE.replace(':userId', comment.userId)}>
+              <span css={nameStyle}>{userData?.displayName || 'Unknown User'}</span>
+            </Link>
             <span css={timeStyle}>{formatCreatedAt(comment.createdAt)}</span>
           </div>
           {comment.userId === currentUserId && (
@@ -140,6 +144,7 @@ const nameStyle = css`
   font-weight: 600;
   margin-right: 8px;
   white-space: nowrap;
+  line-height: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
 `;
@@ -148,6 +153,7 @@ const timeStyle = css`
   color: ${theme.colors.darkGray};
   font-size: ${theme.fontSizes.micro};
   white-space: nowrap;
+  line-height: 100%;
 `;
 
 const menuTriggerStyle = css`

--- a/src/components/comment/CommentSection.tsx
+++ b/src/components/comment/CommentSection.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import defaultProfile from '@/assets/images/default-avatar.svg';
 import { useComments } from '@/hooks/useComments';
 import { useMultipleUsersData } from '@/hooks/useMultipleUsersData';
+import { useUserData } from '@/hooks/useUserData';
 
 import { CommentInput } from './CommentInput';
 import CommentItem from './CommentItem';
@@ -27,15 +28,19 @@ const CommentSection: React.FC<CommentSectionProps> = ({ postId }) => {
   } = useComments(postId || '');
 
   const userIds = Array.from(new Set(comments.map((comment) => comment.userId)));
+  const { userData: currentUserData } = useUserData(currentUser?.uid || null);
   const { usersData } = useMultipleUsersData(userIds);
 
   return (
     <div css={commentSectionStyle}>
-      <CommentInput
-        newCommentContent={newCommentContent}
-        setNewCommentContent={setNewCommentContent}
-        handleCreateComment={handleCreateComment}
-      />
+      <div css={commentContainerStyle}>
+        <img src={currentUserData?.photoURL || ''} alt={currentUserData?.displayName || ''} />
+        <CommentInput
+          newCommentContent={newCommentContent}
+          setNewCommentContent={setNewCommentContent}
+          handleCreateComment={handleCreateComment}
+        />
+      </div>
       <div css={commentsListStyle}>
         {comments.map((comment) => {
           const userData = usersData[comment.userId];
@@ -63,10 +68,22 @@ const commentSectionStyle = css`
   margin-top: 20px;
 `;
 
+const commentContainerStyle = css`
+  display: flex;
+  gap: 12px;
+
+  img {
+    width: 40px;
+    height: 40px;
+    flex-shrink: 0;
+    padding-top: 2px;
+    border-radius: 50%;
+  }
+`;
+
 const commentsListStyle = css`
   display: flex;
   flex-direction: column;
-  gap: 8px;
   margin-top: 16px;
 `;
 

--- a/src/components/comment/CommentSection.tsx
+++ b/src/components/comment/CommentSection.tsx
@@ -36,9 +36,9 @@ const CommentSection: React.FC<CommentSectionProps> = ({ postId }) => {
       <div css={commentContainerStyle}>
         <img src={currentUserData?.photoURL || ''} alt={currentUserData?.displayName || ''} />
         <CommentInput
-          newCommentContent={newCommentContent}
-          setNewCommentContent={setNewCommentContent}
-          handleCreateComment={handleCreateComment}
+          comment={newCommentContent}
+          onChange={setNewCommentContent}
+          onSubmit={handleCreateComment}
         />
       </div>
       <div css={commentsListStyle}>
@@ -70,13 +70,12 @@ const commentSectionStyle = css`
 
 const commentContainerStyle = css`
   display: flex;
-  gap: 12px;
+  gap: 8px;
 
   img {
     width: 40px;
     height: 40px;
     flex-shrink: 0;
-    padding-top: 2px;
     border-radius: 50%;
   }
 `;

--- a/src/components/post/Post.tsx
+++ b/src/components/post/Post.tsx
@@ -175,6 +175,10 @@ const contentStyle = (isDetail: boolean) => css`
     text-overflow: ellipsis;
     overflow: hidden;
   `}
+
+  @media screen and (min-width: ${theme.width.large}) {
+    font-size: ${theme.fontSizes.base};
+  }
 `;
 
 const playlistStyle = css`

--- a/src/components/post/Post.tsx
+++ b/src/components/post/Post.tsx
@@ -86,6 +86,8 @@ const Post: React.FC<PostProps> = ({ post, isDetail = false }) => {
     await updatePostsLikes({ postId: post.postId, userId: currentUser?.uid || '' });
   };
 
+  const postDetailPath = `${PATH.POST_DETAIL.replace(':postId', '')}${post.postId}`;
+
   return (
     <div css={postContainerStyle}>
       <VideoPlayer video={post.video} />
@@ -106,7 +108,9 @@ const Post: React.FC<PostProps> = ({ post, isDetail = false }) => {
             enabled={isSubscribed}
           />
         </div>
-        <p css={contentStyle(isDetail)}>{post.content}</p>
+        <p css={contentStyle(isDetail)}>
+          {isDetail ? post.content : <Link to={postDetailPath}>{post.content}</Link>}
+        </p>
         <p css={playlistStyle}>
           <Link to={post.video}>
             <span>{videoTitle}</span>
@@ -123,11 +127,7 @@ const Post: React.FC<PostProps> = ({ post, isDetail = false }) => {
               )}
               <span>{likesCount}</span>
             </button>
-            <Link
-              to={`${PATH.COMMENT}?postId=${post.postId}`}
-              css={buttonStyle}
-              className="chat-bubble-button"
-            >
+            <Link to={postDetailPath} css={buttonStyle} className="chat-bubble-button">
               <HiOutlineChatBubbleOvalLeft size={20} />
               {comments.length}
             </Link>

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -12,5 +12,5 @@ export const PATH = {
   FOLLOW: '/profile/:userId/follow',
   PRIVACY_POLICY: '/privacyPolicy',
   TERM_OF_SERVICE: '/termOfService',
-  COMMENT: '/comment',
+  POST_DETAIL: '/post/:postId',
 } as const;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,8 +1,11 @@
 import { useEffect, memo } from 'react';
 
 import { css } from '@emotion/react';
+import { HiArrowUturnUp } from 'react-icons/hi2';
+import { LuPartyPopper } from 'react-icons/lu';
 import { useInView } from 'react-intersection-observer';
 
+import FitButton from '@/components/common/buttons/FitButton';
 import Spinner from '@/components/common/loading/Spinner';
 import LogoHeader from '@/components/layout/header/LogoHeader';
 import { PostsTimeLine } from '@/components/post/PostsTimeline';
@@ -19,15 +22,28 @@ const LoadingMessage = ({
   isFetchingNextPage: boolean;
   hasNextPage: boolean;
 }) => {
+  const onClickTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
   if (isFetchingNextPage) {
     return <Spinner customStyle={spinnerStyle} />;
   }
 
   if (!hasNextPage) {
     return (
-      <div css={completionMessageStyle}>
-        <span>모든 포스트를 확인했습니다! </span>
-      </div>
+      <>
+        <div css={completionMessageStyle}>
+          <span>모든 포스트를 확인했습니다!</span>
+          <LuPartyPopper size={20} />
+        </div>
+        <FitButton styleType="secondary" customStyle={topButtonStyle} onClick={onClickTop}>
+          <HiArrowUturnUp /> 맨 위로 가기
+        </FitButton>
+      </>
     );
   }
 
@@ -52,13 +68,9 @@ const HomePage = () => {
   return (
     <>
       <LogoHeader />
-      {posts.length === 0 ? (
-        <div css={noPostsMessageStyle}>
-          <span>😔</span> 포스트를 찾을 수 없습니다. <span>😔</span>
-        </div>
-      ) : null}
+      {posts.length === 0 ? <div css={noPostsMessageStyle}>포스트를 찾을 수 없습니다.</div> : null}
       <MemoizedPostsTimeLine posts={posts} />
-      <div ref={ref}>
+      <div ref={ref} css={messageContainerStyle}>
         <LoadingMessage isFetchingNextPage={isFetchingNextPage} hasNextPage={hasNextPage} />
       </div>
     </>
@@ -69,20 +81,39 @@ const noPostsMessageStyle = css`
   text-align: center;
   padding: 24px;
   color: ${theme.colors.darkGray};
-  font-size: 18px;
-  background-color: ${theme.colors.lightGray};
-  border-radius: 8px;
-  margin: 16px;
 `;
 
 const completionMessageStyle = css`
-  text-align: center;
-  padding: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding-bottom: 16px;
   color: ${theme.colors.darkGray};
-  font-size: 18px;
-  font-weight: bold;
-  border-radius: 8px;
-  margin: 16px;
+  font-size: ${theme.fontSizes.small};
+  font-weight: 600;
+
+  svg {
+    stroke-width: 1.8;
+  }
+`;
+
+const messageContainerStyle = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const topButtonStyle = css`
+  margin: 0 auto;
+  font-weight: 600;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  cursor: pointer;
+
+  svg {
+    stroke-width: 1.2;
+  }
 `;
 
 const spinnerStyle = css`

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { useLocation } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import { getPostByPostId } from '@/api/fetchPosts';
 import CommentSection from '@/components/comment/CommentSection';
@@ -8,13 +8,8 @@ import BackHeader from '@/components/layout/header/BackHeader';
 import Post from '@/components/post/Post';
 import { PostModel } from '@/types/post';
 
-const useQuery = () => {
-  return new URLSearchParams(useLocation().search);
-};
-
-export const Comment = () => {
-  const query = useQuery();
-  const postId = query.get('postId');
+const PostDetailPage = () => {
+  const { postId } = useParams();
   const [post, setPost] = useState<PostModel | null>(null);
 
   useEffect(() => {
@@ -31,8 +26,10 @@ export const Comment = () => {
   return (
     <>
       <BackHeader title="" />
-      {post && <Post id={postId || ''} post={post} />}
+      {post && <Post id={postId || ''} post={post} isDetail={true} />}
       <CommentSection postId={postId || ''} />
     </>
   );
 };
+
+export default PostDetailPage;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- AI에게 리뷰를 받고 싶지 않다면 🤷‍♀️이모지를 제거해주세요. -->
@coderabbitai: i🤷‍♀️gnore

## 📋 작업 내용

- 타임라인에서 모든 포스트를 확인했을 때 위로가기 버튼 추가
- 댓글에서 닉네임 클릭 시 해당 유저의 프로필 페이지로 이동

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/4db08264-fb01-4d28-81ab-fe1072b39bbb)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
## Release Notes

### New Feature
- 포스트 상세 페이지(`PostDetailPage`) 추가: 댓글 아이콘 클릭 시 해당 포스트의 상세 페이지로 이동.
- 위로가기 버튼 추가: 타임라인에서 위로가기 버튼을 통해 빠르게 상단으로 이동 가능.

### Style
- 댓글 입력란 및 수정 기능 디자인 개선: Enter 키로 댓글 작성, 프로필 이미지와 닉네임 UI 업데이트.
- 완료 메시지 및 취소 버튼 스타일 변경.

### Refactor
- `Comment` 페이지를 `PostDetailPage`로 대체하고, `useQuery` 대신 `useParams` 훅 사용.
- 포스트 컴포넌트에서 상세 페이지와 타임라인 표시 로직 분리.
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->