### PR TITLE
[Enhancement] 유튜브 조회수 포맷팅 함수 추가

### DIFF
--- a/src/components/playlistDetail/PlaylistContentsItem.tsx
+++ b/src/components/playlistDetail/PlaylistContentsItem.tsx
@@ -18,6 +18,7 @@ import { textEllipsis } from '@/styles/GlobalStyles';
 import theme from '@/styles/theme';
 import { VideoModel } from '@/types/playlist';
 import { formatRelativeDate } from '@/utils/date';
+import { formatVideoViewCount } from '@/utils/youtubeUtils';
 
 interface PlaylistContentItemProps {
   video: VideoModel;
@@ -89,7 +90,8 @@ const PlaylistContentsItem: React.FC<PlaylistContentItemProps> = ({
                 <h2>{videoData.title}</h2>
                 <span>{videoData.creator}</span>
                 <span>
-                  조회수 {videoData.views} · {formatRelativeDate(videoData.uploadDate)}
+                  조회수 {formatVideoViewCount(videoData.views)} ·{' '}
+                  {formatRelativeDate(videoData.uploadDate)}
                 </span>
               </div>
             </a>

--- a/src/utils/youtubeUtils.ts
+++ b/src/utils/youtubeUtils.ts
@@ -16,3 +16,15 @@ export const validateVideoId = async (id: string): Promise<boolean> => {
     return false;
   }
 };
+
+const formatDecimal = (number: number): string => {
+  return number.toFixed(1).replace('.0', '');
+};
+
+export const formatVideoViewCount = (count: number): string => {
+  if (count < 1000) return `${count}회`;
+  if (count < 10000) return `${formatDecimal(count / 1000)}천회`;
+  if (count < 100000) return `${formatDecimal(count / 10000)}만회`;
+  if (count < 100000000) return `${Math.floor(count / 10000)}만회`;
+  return `${Math.floor(count / 100000000)}억회`;
+};


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- AI에게 리뷰를 받고 싶지 않다면 🤷‍♀️이모지를 제거해주세요. -->
@coderabbitai: i🤷‍♀️gnore

## 📋 작업 내용

유튜브 조회수 포맷팅 함수 추가하고 적용까지 했습니다!

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/b8f97d3d-8d9b-40c9-9c08-01cdd03c0564)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- New Feature: 유튜브 조회수 포맷팅 기능 추가
  - 유튜브 조회수를 더 읽기 쉽게 표시하기 위해 `formatVideoViewCount` 함수를 도입했습니다.
  - 이제 조회수가 적절한 형식으로 변환되어 사용자에게 표시됩니다.
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->