### PR TITLE
[Design] 기타 스타일 수정

### DIFF
--- a/src/components/comment/CommentInput.tsx
+++ b/src/components/comment/CommentInput.tsx
@@ -49,7 +49,7 @@ export const CommentInput: React.FC<CommentInputProps> = ({
         value={comment}
         onChange={(e) => onChange(e.target.value)}
         onKeyDown={handleKeyDown}
-        placeholder="답글을 작성해주세요"
+        placeholder="댓글을 작성해주세요"
         onCompositionStart={handleCompositionStart}
         onCompositionEnd={handleCompositionEnd}
       />

--- a/src/components/comment/CommentSection.tsx
+++ b/src/components/comment/CommentSection.tsx
@@ -1,10 +1,12 @@
 import { css } from '@emotion/react';
+import { HiOutlineChatBubbleOvalLeft } from 'react-icons/hi2';
 
 import defaultProfile from '@/assets/images/default-avatar.svg';
 import Avatar from '@/components/common/Avatar';
 import { useComments } from '@/hooks/useComments';
 import { useMultipleUsersData } from '@/hooks/useMultipleUsersData';
 import { useUserData } from '@/hooks/useUserData';
+import { emptyMessageStyle } from '@/styles/GlobalStyles';
 
 import { CommentInput } from './CommentInput';
 import CommentItem from './CommentItem';
@@ -66,6 +68,12 @@ const CommentSection: React.FC<CommentSectionProps> = ({ postId }) => {
             />
           );
         })}
+        {comments.length === 0 && (
+          <div css={emptyMessageStyle}>
+            <HiOutlineChatBubbleOvalLeft />
+            <p>첫 댓글을 달아주세요!</p>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/playlist/Playlists.tsx
+++ b/src/components/playlist/Playlists.tsx
@@ -3,7 +3,7 @@ import { PiYoutubeLogo } from 'react-icons/pi';
 
 import VideoThumbnail from '@/components/playlist/VideoThumbnail';
 import { useAuth } from '@/hooks/useAuth';
-import { textEllipsis } from '@/styles/GlobalStyles';
+import { emptyMessageStyle, textEllipsis } from '@/styles/GlobalStyles';
 import theme from '@/styles/theme';
 import { PlaylistModel } from '@/types/playlist';
 
@@ -50,8 +50,8 @@ const Playlists: React.FC<PlaylistListProps> = ({
             ))}
       </div>
       {playlists.length === 0 && (
-        <div css={messageStyle}>
-          <PiYoutubeLogo size={48} />
+        <div css={[emptyMessageStyle]}>
+          <PiYoutubeLogo />
           <p>마음에 드는 플리를 구독해 보세요!</p>
         </div>
       )}
@@ -97,20 +97,6 @@ const itemStyle = (isColumn: boolean) => css`
         font-size: ${theme.fontSizes.small};
       }
     }
-  }
-`;
-
-const messageStyle = css`
-  text-align: center;
-  margin-top: 60px;
-  color: ${theme.colors.darkestGray};
-
-  svg {
-    stroke-width: 0.5px;
-  }
-
-  p {
-    margin-top: 4px;
   }
 `;
 

--- a/src/components/playlistDetail/PlaylistContentsItem.tsx
+++ b/src/components/playlistDetail/PlaylistContentsItem.tsx
@@ -219,7 +219,7 @@ const playlistItemStyle = css`
 `;
 
 const selectedStyle = css`
-  background-color: #e0e0e0;
+  background-color: ${theme.colors.lightestGray};
   border-radius: 8px;
   transition: background-color 0.3s ease;
 `;

--- a/src/components/post/Post.tsx
+++ b/src/components/post/Post.tsx
@@ -26,6 +26,7 @@ import {
   useCheckSubscription,
 } from '@/hooks/useSubscribePlaylist';
 import { useUserData } from '@/hooks/useUserData';
+import { textEllipsis } from '@/styles/GlobalStyles';
 import theme from '@/styles/theme';
 import { PostModel } from '@/types/post';
 import { formatCreatedAt } from '@/utils/date';
@@ -135,8 +136,9 @@ const Post: React.FC<PostProps> = ({ post, isDetail = false }) => {
               {comments.length}
             </Link>
           </div>
-          <button css={pliStyle} onClick={handleButtonClick}>
-            {playlist?.title} (<span>{playlist?.videos.length}</span>)
+          <button css={[pliStyle]} onClick={handleButtonClick}>
+            <span css={textEllipsis(1)}>{playlist?.title}</span> (
+            <span>{playlist?.videos.length}</span>)
           </button>
         </div>
       </div>
@@ -241,11 +243,13 @@ const likeButtonStyle = (isLiked: boolean) => css`
 `;
 
 const pliStyle = css`
+  display: flex;
+  max-width: 200px;
   color: ${theme.colors.darkestGray};
   font-size: ${theme.fontSizes.small};
-  text-decoration: underline;
   background: none;
   cursor: pointer;
+  text-decoration: underline;
 `;
 
 export default Post;

--- a/src/pages/ProfileEdit.tsx
+++ b/src/pages/ProfileEdit.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/react';
 import { HiOutlinePhoto } from 'react-icons/hi2';
 import { useNavigate, useLocation } from 'react-router-dom';
 
-import defaultImage from '@/assets/images/default-avatar.svg';
+import Avatar from '@/components/common/Avatar';
 import FullButton from '@/components/common/buttons/FullButton';
 import Input from '@/components/common/inputs/Input';
 import Textarea from '@/components/common/inputs/Textarea';
@@ -84,13 +84,7 @@ const ProfileEditPage: React.FC = () => {
       <BackHeader title="프로필 수정" />
       <div css={pageContentStyle}>
         <div css={imageContainerStyle}>
-          <div>
-            {photoURL ? (
-              <img src={photoURL} alt="Profile" />
-            ) : (
-              <img src={defaultImage} alt="" className="image-placeholder" />
-            )}
-          </div>
+          <Avatar size="extraLarge" url={photoURL} />
           <span onClick={handleImageClick}>
             <HiOutlinePhoto size={20} />
           </span>

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -150,4 +150,19 @@ export const textEllipsis = (lineClamp: number) => css`
   }
 `;
 
+export const emptyMessageStyle = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 60px;
+  color: ${theme.colors.darkestGray};
+  font-size: 32px;
+
+  p {
+    font-size: ${theme.fontSizes.small};
+  }
+`;
+
 export default GlobalStyles;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- AI에게 리뷰를 받고 싶지 않다면 🤷‍♀️이모지를 제거해주세요. -->
@coderabbitai: i🤷‍♀️gnore

## 📋 작업 내용

emptyMessageStyle 전역으로 이동 (구독한 플레이리스트 비었을때, 댓글 없을때 사용중)
기타 자잘한 스타일 수정

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
### Release Notes

#### New Feature
- 댓글이 없을 때 특정 스타일과 메시지를 표시하는 기능 추가 (CommentSection, Playlists).

#### Style
- `CommentInput`의 placeholder 텍스트를 "답글을 작성해주세요"에서 "댓글을 작성해주세요"로 변경.
- 선택된 스타일의 배경색을 `${theme.colors.lightestGray}`로 변경 (PlaylistContentsItem).
- `Post` 컴포넌트에 텍스트 자르기 스타일 및 레이아웃 수정.

#### Refactor
- `emptyMessageStyle`를 전역 스타일로 이동하여 재사용성 향상.
- ProfileEditPage에서 defaultImage를 Avatar 컴포넌트로 대체하여 이미지 표시 방식 개선.
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->