### PR TITLE
[Hotfix] 플레이리스트디테일 라우팅 경로 에러 해결

### DIFF
--- a/src/components/layout/header/BackHeader.tsx
+++ b/src/components/layout/header/BackHeader.tsx
@@ -24,7 +24,7 @@ const BackHeader: React.FC<BackHeaderProps> = ({
 }) => {
   const navigate = useNavigate();
 
-  const onClick = () => onBackClick?.() || navigate(-1);
+  const onClick = () => (onBackClick ? onBackClick() : navigate(-1));
 
   return (
     <Header

--- a/src/pages/PlaylistDetail.tsx
+++ b/src/pages/PlaylistDetail.tsx
@@ -13,6 +13,7 @@ import { UserModel } from '@/types/user';
 const PlaylistDetailPage = () => {
   const { id: playlistId } = useParams<{ id: string }>();
   const location = useLocation();
+  console.log(location);
   const state = location.state as { selectPli?: boolean };
   const navigate = useNavigate();
   const { data: playlist, isLoading, isError } = usePlaylistById(playlistId);
@@ -37,11 +38,7 @@ const PlaylistDetailPage = () => {
   }
 
   const handleBack = () => {
-    navigate(`/playlist`, { replace: true });
-
-    setTimeout(() => {
-      navigate(`/playlist`, { replace: true });
-    }, 0);
+    navigate(`/playlist`);
   };
 
   const userModel: UserModel = {

--- a/src/pages/PlaylistDetail.tsx
+++ b/src/pages/PlaylistDetail.tsx
@@ -13,7 +13,6 @@ import { UserModel } from '@/types/user';
 const PlaylistDetailPage = () => {
   const { id: playlistId } = useParams<{ id: string }>();
   const location = useLocation();
-  console.log(location);
   const state = location.state as { selectPli?: boolean };
   const navigate = useNavigate();
   const { data: playlist, isLoading, isError } = usePlaylistById(playlistId);


### PR DESCRIPTION
- BackHeader.tsx 에서 onClick 함수를 수정
- PlaylistDetail.tsx에서 handleBack 함수 안에 navigate 함수가 1개만
  남도록 수정

```js
const onClick = () => (onBackClick ? onBackClick() : navigate(-1));
```
```js

  const handleBack = () => {
    navigate(`/playlist`);
  };

```


<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
## Release Notes

### Refactor
- `BackHeader.tsx`: Simplified the `onClick` function for better readability and maintainability.
- `PlaylistDetail.tsx`: Improved navigation logic by refining the `handleBack` function, ensuring a more consistent user experience when navigating back from the playlist detail page.

These changes enhance code clarity and improve the overall user experience with more reliable navigation behavior.
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->