### PR TITLE
[Enhancement] 포스트 상세 페이지 드롭다운을 모달로 변경 및 EmptyMessage 컴포넌트 추가

### DIFF
--- a/src/components/EmptyMessage.tsx
+++ b/src/components/EmptyMessage.tsx
@@ -1,0 +1,38 @@
+import { ReactNode } from 'react';
+
+import { css, SerializedStyles } from '@emotion/react';
+import { IconType } from 'react-icons';
+
+import theme from '@/styles/theme';
+
+interface EmptyMessageProps {
+  Icon: IconType;
+  children: ReactNode;
+  customStyle?: SerializedStyles;
+}
+
+const EmptyMessage: React.FC<EmptyMessageProps> = ({ Icon, customStyle, children }) => {
+  return (
+    <div css={[emptyMessageStyle, customStyle]}>
+      <Icon />
+      <p>{children}</p>
+    </div>
+  );
+};
+
+const emptyMessageStyle = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin: 60px 0;
+  color: ${theme.colors.darkestGray};
+  font-size: 32px;
+
+  p {
+    font-size: ${theme.fontSizes.small};
+  }
+`;
+
+export default EmptyMessage;

--- a/src/components/comment/CommentItem.tsx
+++ b/src/components/comment/CommentItem.tsx
@@ -1,12 +1,18 @@
+import { useState } from 'react';
+
 import { css } from '@emotion/react';
-import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
-import { HiDotsVertical, HiPencil, HiTrash } from 'react-icons/hi';
-import { HiXMark } from 'react-icons/hi2';
+import {
+  HiOutlineEllipsisVertical,
+  HiOutlineTrash,
+  HiXMark,
+  HiOutlinePencil,
+} from 'react-icons/hi2';
 import { Link } from 'react-router-dom';
 
 import { CommentInput } from '@/components/comment/CommentInput';
 import Avatar from '@/components/common/Avatar';
 import FitButton from '@/components/common/buttons/FitButton';
+import OptionModal from '@/components/common/modals/OptionModal';
 import { PATH } from '@/constants/path';
 import theme from '@/styles/theme';
 import { CommentModel } from '@/types/comment';
@@ -39,6 +45,31 @@ const CommentItem: React.FC<CommentItemProps> = ({
   handleCompositionStart,
   handleCompositionEnd,
 }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleOpenModal = () => setIsModalOpen(true);
+  const handleCloseModal = () => setIsModalOpen(false);
+
+  const modalOptions = [
+    {
+      label: '댓글 수정하기',
+      Icon: HiOutlinePencil,
+      onClick: () => {
+        setEditingCommentId(comment.id);
+        setEditingContent(comment.content);
+        handleCloseModal();
+      },
+    },
+    {
+      label: '댓글 삭제하기',
+      Icon: HiOutlineTrash,
+      onClick: () => {
+        handleDeleteComment(comment.id);
+        handleCloseModal();
+      },
+    },
+  ];
+
   return (
     <div css={commentStyle}>
       <Avatar url={userData?.photoURL} size="medium" customStyle={avatarStyle} />
@@ -51,35 +82,16 @@ const CommentItem: React.FC<CommentItemProps> = ({
             <span css={timeStyle}>{formatCreatedAt(comment.createdAt)}</span>
           </div>
           {comment.userId === currentUserId && (
-            <DropdownMenu.Root>
-              <DropdownMenu.Trigger asChild>
-                <button css={menuTriggerStyle} data-testid="comment-dropdown-button">
-                  <HiDotsVertical size={18} />
-                </button>
-              </DropdownMenu.Trigger>
-
-              <DropdownMenu.Portal>
-                <DropdownMenu.Content css={menuContentStyle}>
-                  <DropdownMenu.Item
-                    css={menuItemStyle}
-                    onSelect={() => {
-                      setEditingCommentId(comment.id);
-                      setEditingContent(comment.content);
-                    }}
-                    data-testid="edit-comment-button"
-                  >
-                    <HiPencil /> 댓글 수정
-                  </DropdownMenu.Item>
-                  <DropdownMenu.Item
-                    css={menuItemStyle}
-                    onSelect={() => handleDeleteComment(comment.id)}
-                    data-testid="delete-comment-button"
-                  >
-                    <HiTrash /> 댓글 삭제
-                  </DropdownMenu.Item>
-                </DropdownMenu.Content>
-              </DropdownMenu.Portal>
-            </DropdownMenu.Root>
+            <>
+              <button
+                css={menuTriggerStyle}
+                onClick={handleOpenModal}
+                data-testid="comment-vertical-button"
+              >
+                <HiOutlineEllipsisVertical size={20} />
+              </button>
+              <OptionModal isOpen={isModalOpen} onClose={handleCloseModal} options={modalOptions} />
+            </>
           )}
         </div>
         {editingCommentId === comment.id ? (
@@ -164,7 +176,7 @@ const menuTriggerStyle = css`
   height: 18px;
   margin-left: 8px;
   border: none;
-  color: ${theme.colors.darkGray};
+  color: ${theme.colors.darkestGray};
   background: none;
   cursor: pointer;
 `;
@@ -186,42 +198,6 @@ const editCommentContainerStyle = css`
 
 const editInputStyle = css`
   background-color: ${theme.colors.white};
-`;
-
-const menuContentStyle = css`
-  min-width: 120px;
-  background-color: white;
-  border-radius: 6px;
-  padding: 5px;
-  box-shadow:
-    0px 10px 38px -10px rgba(22, 23, 24, 0.35),
-    0px 10px 20px -15px rgba(22, 23, 24, 0.2);
-`;
-
-const menuItemStyle = css`
-  all: unset;
-  font-size: 13px;
-  line-height: 1;
-  color: ${theme.colors.black};
-  border-radius: 3px;
-  display: flex;
-  align-items: center;
-  height: 25px;
-  padding: 0 5px;
-  position: relative;
-  padding-left: 25px;
-  user-select: none;
-
-  &:hover {
-    background-color: ${theme.colors.lightGray};
-  }
-
-  svg {
-    position: absolute;
-    left: 5px;
-    top: 50%;
-    transform: translateY(-50%);
-  }
 `;
 
 const cancelButtonStyle = css`

--- a/src/components/comment/CommentSection.tsx
+++ b/src/components/comment/CommentSection.tsx
@@ -3,10 +3,10 @@ import { HiOutlineChatBubbleOvalLeft } from 'react-icons/hi2';
 
 import defaultProfile from '@/assets/images/default-avatar.svg';
 import Avatar from '@/components/common/Avatar';
+import EmptyMessage from '@/components/EmptyMessage';
 import { useComments } from '@/hooks/useComments';
 import { useMultipleUsersData } from '@/hooks/useMultipleUsersData';
 import { useUserData } from '@/hooks/useUserData';
-import { emptyMessageStyle } from '@/styles/GlobalStyles';
 
 import { CommentInput } from './CommentInput';
 import CommentItem from './CommentItem';
@@ -69,10 +69,7 @@ const CommentSection: React.FC<CommentSectionProps> = ({ postId }) => {
           );
         })}
         {comments.length === 0 && (
-          <div css={emptyMessageStyle}>
-            <HiOutlineChatBubbleOvalLeft />
-            <p>첫 댓글을 달아주세요!</p>
-          </div>
+          <EmptyMessage Icon={HiOutlineChatBubbleOvalLeft}>첫 댓글을 달아주세요!</EmptyMessage>
         )}
       </div>
     </div>

--- a/src/components/playlist/Playlists.tsx
+++ b/src/components/playlist/Playlists.tsx
@@ -1,9 +1,10 @@
 import { css, SerializedStyles } from '@emotion/react';
 import { PiYoutubeLogo } from 'react-icons/pi';
 
+import EmptyMessage from '@/components/EmptyMessage';
 import VideoThumbnail from '@/components/playlist/VideoThumbnail';
 import { useAuth } from '@/hooks/useAuth';
-import { emptyMessageStyle, textEllipsis } from '@/styles/GlobalStyles';
+import { textEllipsis } from '@/styles/GlobalStyles';
 import theme from '@/styles/theme';
 import { PlaylistModel } from '@/types/playlist';
 
@@ -51,10 +52,7 @@ const Playlists: React.FC<PlaylistListProps> = ({
             ))}
       </div>
       {playlists.length === 0 && (
-        <div css={[emptyMessageStyle]}>
-          <PiYoutubeLogo />
-          <p>마음에 드는 플리를 구독해 보세요!</p>
-        </div>
+        <EmptyMessage Icon={PiYoutubeLogo}>마음에 드는 플리를 구독해 보세요!</EmptyMessage>
       )}
     </>
   );

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -8,6 +8,7 @@ import { getPostsByUserId, getPostsFilteredLikes } from '@/api/fetchPosts';
 import Spinner from '@/components/common/loading/Spinner';
 import TabContent from '@/components/common/tabs/TabContent';
 import TabMenu from '@/components/common/tabs/TabMenu';
+import EmptyMessage from '@/components/EmptyMessage';
 import LogoHeader from '@/components/layout/header/LogoHeader';
 import AddPlaylistButton from '@/components/playlist/AddPlaylistButton';
 import Playlists from '@/components/playlist/Playlists';
@@ -136,6 +137,9 @@ const ProfilePage: React.FC = () => {
             ) : (
               userPosts.map((post) => <Post key={post.postId} post={post} id={post.postId} />)
             )}
+            {userPosts.length === 0 && (
+              <EmptyMessage Icon={HiOutlinePencil}>아직 포스트가 없습니다</EmptyMessage>
+            )}
           </TabContent>
           <TabContent id="pli" activeTabId={activeTab}>
             {isOwnProfile && (
@@ -151,6 +155,9 @@ const ProfilePage: React.FC = () => {
             ) : (
               <Playlists playlists={playlists || []} onPlaylistClick={handlePlaylistClick} />
             )}
+            {(!playlists || playlists.filter((playlist) => playlist.isPublic).length === 0) && (
+              <EmptyMessage Icon={HiOutlinePlay}>아직 공개된 플리가 없습니다</EmptyMessage>
+            )}
           </TabContent>
           <TabContent id="likes" activeTabId={activeTab}>
             {loadingLikedPosts ? (
@@ -161,6 +168,9 @@ const ProfilePage: React.FC = () => {
               <div>{error}</div>
             ) : (
               likedPosts.map((post) => <Post key={post.postId} post={post} id={post.postId} />)
+            )}
+            {likedPosts.length === 0 && (
+              <EmptyMessage Icon={HiOutlineHeart}>아직 좋아요 한 포스트가 없습니다</EmptyMessage>
             )}
           </TabContent>
         </TabMenu>

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -150,19 +150,4 @@ export const textEllipsis = (lineClamp: number) => css`
   }
 `;
 
-export const emptyMessageStyle = css`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  margin: 60px 0;
-  color: ${theme.colors.darkestGray};
-  font-size: 32px;
-
-  p {
-    font-size: ${theme.fontSizes.small};
-  }
-`;
-
 export default GlobalStyles;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- AI에게 리뷰를 받고 싶지 않다면 🤷‍♀️이모지를 제거해주세요. -->
@coderabbitai: i🤷‍♀️gnore

## 📋 작업 내용

- 포스트 상세 페이지에서 댓글 수정/삭제 기존 디자인이 모달인데 드롭다운으로 되어있어서 모달로 수정
- EmptyMessage 컴포넌트를 추가해 포스트, 좋아요한 포스트 등이 비었을 때의 메시지를 출력

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
## Release Notes

### New Feature
- `EmptyMessage` 컴포넌트 추가: 댓글, 플레이리스트, 프로필 페이지 등에서 데이터가 없을 때 사용자에게 메시지를 표시합니다.

### Refactor
- 댓글 수정/삭제 기능을 드롭다운 메뉴에서 모달로 변경.
- `emptyMessageStyle` 스타일 제거 및 `EmptyMessage` 컴포넌트로 대체.

### Style
- CSS 스타일 및 아이콘 업데이트.
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->