### PR TITLE
[Fix] 타임라인에 자신 포스트가 없는 버그수정

### DIFF
--- a/src/api/fetchPosts.ts
+++ b/src/api/fetchPosts.ts
@@ -128,7 +128,7 @@ export const getPostsByFollowingUsers = async ({
     return [];
   }
 
-  const followingUserIds = userDoc.data().following;
+  const followingUserIds = userDoc.data().following ?? [];
 
   let q = query(
     postsCollection,

--- a/src/hooks/useFilteredPostsTimelines.ts
+++ b/src/hooks/useFilteredPostsTimelines.ts
@@ -25,13 +25,15 @@ export const useFilteredPostsTimelinesQuery = ({ userId }: { userId: string }) =
         const noneFollowingUserPosts = await getPostsByNonFollowingUsers({
           userId,
           count: POSTS_FETCH_LIMIT,
-          lastPostId: pageParam as string | undefined,
+          lastPostId:
+            followingUserPosts[followingUserPosts.length - 1]?.postId ||
+            (pageParam as string | undefined),
         });
-        posts = noneFollowingUserPosts;
+        posts = [...noneFollowingUserPosts, ...followingUserPosts];
       }
       return {
         posts: posts,
-        nextCursor: posts.length === POSTS_FETCH_LIMIT ? posts[posts.length - 1].postId : null,
+        nextCursor: posts.length > 0 ? posts[posts.length - 1].postId : null,
       };
     },
     getNextPageParam: (lastPage) => lastPage.nextCursor,


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- AI에게 리뷰를 받고 싶지 않다면 🤷‍♀️이모지를 제거해주세요. -->
@coderabbitai: i🤷‍♀️gnore

## 📋 작업 내용

- fetchPost.ts에서서 followingUserIds가 undefind가 되지 않도록
  following이 0인 경우 빈배열을 할당함.

### useFilteredPostsTimelinesQuery 파일 수정 내역
- 팔로잉 포스트와 논팔로잉 포스트가 중복이 되지 않도록, 팔로잉 포스트가 3개 이하 일 때 마지막 팔로잉 포스트 기준으로 포스트를 fetch해서 가져옵니다.
- nextCursor를 수정해서 3개 이하가 아닌 0개 이하가 될 때만 useFilteredPostsTimelinesQuery 쿼리 fetch를 중단 시킵니다.

## 🔧 변경 사항

```js
interface UseFilteredPostsTimelinesProps {
  posts: PostModel[];
  nextCursor: string | null;
}

const POSTS_FETCH_LIMIT = 3;

export const useFilteredPostsTimelinesQuery = ({ userId }: { userId: string }) => {
  return useInfiniteQuery<UseFilteredPostsTimelinesProps>({
    queryKey: ['filteredPostsTimelines', userId],
    queryFn: async ({ pageParam = undefined }) => {
      let posts;
      const followingUserPosts = await getPostsByFollowingUsers({
        userId,
        count: POSTS_FETCH_LIMIT,
        lastPostId: pageParam as string | undefined,
      });
      posts = followingUserPosts;
      if (followingUserPosts.length < POSTS_FETCH_LIMIT) {
        const noneFollowingUserPosts = await getPostsByNonFollowingUsers({
          userId,
          count: POSTS_FETCH_LIMIT,
          lastPostId:
            followingUserPosts[followingUserPosts.length - 1]?.postId ||
            (pageParam as string | undefined),
        });
        posts = [...noneFollowingUserPosts, ...followingUserPosts];
      }
      return {
        posts: posts,
        nextCursor: posts.length > 0 ? posts[posts.length - 1].postId : null,
      };
    },
    getNextPageParam: (lastPage) => lastPage.nextCursor,
    initialPageParam: undefined,
  });
};

```

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Bug Fix: `getPostsByFollowingUsers` 함수에서 `followingUserIds`가 `undefined`인 경우 기본값으로 빈 배열을 할당하여 오류를 방지.
- Bug Fix: `useFilteredPostsTimelinesQuery` 함수 내 중복된 포스트를 가져오지 않도록 수정하고, 더 이상 포스트를 가져오지 못하는 오류 해결. 마지막 포스트의 ID를 반환하도록 `nextCursor` 계산 로직 변경.
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->