### PR TITLE
[Bug] 플레이리스트 상세 페이지 경로 문제 해결

### DIFF
--- a/src/pages/AddVideos.tsx
+++ b/src/pages/AddVideos.tsx
@@ -25,7 +25,8 @@ const AddVideosPage: React.FC = () => {
 
   const { mutate: addVideosToPlaylist, isPending } = useAddVideosToPlaylist(playlistId);
 
-  const handleOnClose = () => navigate(`/playlist/${playlistId}`);
+  const handleOnClose = () =>
+    navigate(`/playlist/${playlistId}`, { state: { from: '/addVideos' } });
 
   const handleOnAdd = () => {
     if (playlistId && videos.length > 0) {

--- a/src/pages/PlaylistDetail.tsx
+++ b/src/pages/PlaylistDetail.tsx
@@ -31,6 +31,16 @@ const PlaylistDetailPage = () => {
     return;
   }
 
+  const onBackClick = () => {
+    const previousPath = location.state?.from as string;
+
+    if (previousPath && previousPath.includes('addVideos')) {
+      navigate('/playlist');
+    } else {
+      navigate(-1);
+    }
+  };
+
   if (isError || !playlist) {
     console.warn('플레이리스트를 찾을 수 없습니다.');
     return <p>플레이리스트를 찾을 수 없습니다.</p>;
@@ -59,6 +69,7 @@ const PlaylistDetailPage = () => {
   return (
     <>
       <BackHeader
+        onBackClick={onBackClick}
         title={state?.selectPli ? '동영상 선택' : undefined}
         rightButtonText={'완료'}
         onRightButtonClick={state?.selectPli ? handleCompleteClick : undefined}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- AI에게 리뷰를 받고 싶지 않다면 🤷‍♀️이모지를 제거해주세요. -->
@coderabbitai: i🤷‍♀️gnore

## 📋 작업 내용

프로필 페이지 -> 플리 탭 -> 플리 선택 -> 동영상 추가 눌렀을 때 생기는 링크 오류 해결

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
### Release Notes

- **New Feature**: Enhanced navigation by updating the `handleOnClose` function in `AddVideos.tsx` to include state information when redirecting to `/playlist/${playlistId}`.
- **New Feature**: Added `onBackClick` functionality in `PlaylistDetailPage` to improve user experience with a more intuitive back navigation using the `BackHeader` component.
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->