### PR TITLE
[Bug] 타임라인 게시물 중복 해결, 타임라인에 본인 포스트가 올라오지 않는 오류 해결(#137)

### DIFF
--- a/src/api/fetchPosts.ts
+++ b/src/api/fetchPosts.ts
@@ -128,7 +128,7 @@ export const getPostsByFollowingUsers = async ({
     return [];
   }
 
-  const followingUserIds = userDoc.data().following;
+  const followingUserIds = userDoc.data().following ?? [];
 
   let q = query(
     postsCollection,

--- a/src/hooks/useFilteredPostsTimelines.ts
+++ b/src/hooks/useFilteredPostsTimelines.ts
@@ -25,13 +25,15 @@ export const useFilteredPostsTimelinesQuery = ({ userId }: { userId: string }) =
         const noneFollowingUserPosts = await getPostsByNonFollowingUsers({
           userId,
           count: POSTS_FETCH_LIMIT,
-          lastPostId: pageParam as string | undefined,
+          lastPostId:
+            followingUserPosts[followingUserPosts.length - 1]?.postId ||
+            (pageParam as string | undefined),
         });
-        posts = noneFollowingUserPosts;
+        posts = [...followingUserPosts, ...noneFollowingUserPosts];
       }
       return {
         posts: posts,
-        nextCursor: posts.length === POSTS_FETCH_LIMIT ? posts[posts.length - 1].postId : null,
+        nextCursor: posts.length > 2 ? posts[posts.length - 1].postId : null,
       };
     },
     getNextPageParam: (lastPage) => lastPage.nextCursor,


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- AI에게 리뷰를 받고 싶지 않다면 🤷‍♀️이모지를 제거해주세요. -->
@coderabbitai: i🤷‍♀️gnore

## 📋 작업 내용

- 타임라인 포스트 중복 해결

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
### Release Notes

#### Bug Fix
- Fixed an issue where `userDoc.data().following` could be `null` by setting a default empty array in `fetchPosts.ts`.
- Resolved duplicate timeline posts in `useFilteredPostsTimelinesQuery` by adjusting the merging logic of `followingUserPosts` and `noneFollowingUserPosts`, and modifying the `lastPostId` value. The `nextCursor` is now set only when its value is greater than 2.
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->