### PR TITLE
[Test] 포스트에 플레이리스트 제목이 제대로 뜨는지 테스트코드 추가

### DIFF
--- a/src/components/post/Post.tsx
+++ b/src/components/post/Post.tsx
@@ -210,7 +210,9 @@ const Post: React.FC<PostProps> = ({ post, isDetail = false }) => {
             onClick={isClickable ? handleButtonClick : undefined}
             style={{ cursor: isClickable ? 'pointer' : 'default' }}
           >
-            <span css={textEllipsis(1)}>{playlistLabel}</span>
+            <span css={textEllipsis(1)} data-testid="playlist-title">
+              {playlistLabel}
+            </span>
             {isPublicPlaylist && <span>({playlist?.videos.length})</span>}
           </button>
         </div>

--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -1,10 +1,30 @@
 import playwrightFirebasePlugin from '@nearform/playwright-firebase';
 import { test as base } from '@playwright/test';
+import * as dotenv from 'dotenv';
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+
+dotenv.config();
 
 const serviceAccount = JSON.parse(process.env.SERVICE_ACCOUNT!);
 const UID = process.env.REACT_APP_UID!;
 const options = JSON.parse(process.env.REACT_APP_FIREBASE_CONFIG!);
 
 const firebaseTest = playwrightFirebasePlugin(serviceAccount, options, UID, base);
+
+const firebaseConfig = {
+  apiKey: process.env.VITE_FIREBASE_API_KEY,
+  authDomain: process.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.VITE_FIREBASE_APP_ID,
+  measurementId: process.env.VITE_FIREBASE_MEASUREMENT_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+export const db = getFirestore(app);
+export const auth = getAuth(app);
 
 export const test = firebaseTest;

--- a/tests/playlistTitle.spec.ts
+++ b/tests/playlistTitle.spec.ts
@@ -1,0 +1,181 @@
+import { expect } from '@playwright/test';
+import { collection, doc, getDoc, getDocs, query, where } from 'firebase/firestore';
+
+import { PlaylistModel } from './../src/types/playlist';
+import { PostModel } from './../src/types/post';
+import { test as authTest, db } from './auth.setup';
+
+authTest.describe('포스트 상세 페이지', () => {
+  authTest.beforeEach(async ({ page, auth }) => {
+    await page.goto('/signin');
+    await auth.login(page);
+    await page.goto('/');
+  });
+
+  authTest('포스트 컴포넌트에서 플레이리스트 제목이 표시되어야 한다.', async ({ page }) => {
+    await page.waitForSelector('[data-testid="playlist-title"]');
+
+    const playlistTitle = await page.locator('[data-testid="playlist-title"]').first().innerText();
+
+    expect(playlistTitle).not.toBeNull();
+  });
+
+  authTest('공개 플레이리스트의 제목이 올바르게 표시되어야 한다', async ({ page, auth }) => {
+    const { playlistData } = await setupTest(page, auth, 'public');
+
+    const displayedTitle = await page.locator('[data-testid="playlist-title"]').textContent();
+    expect(displayedTitle).toContain(playlistData?.title);
+  });
+
+  authTest('비공개 플레이리스트의 제목이 본인에게는 표시되어야 한다', async ({ page, auth }) => {
+    const { playlistData } = await setupTest(page, auth, 'private-own');
+
+    const displayedTitle = await page.locator('[data-testid="playlist-title"]').textContent();
+    expect(displayedTitle).toContain(playlistData?.title);
+  });
+
+  authTest(
+    '타인의 비공개 플레이리스트는 "비공개 플레이리스트"로 표시되어야 한다',
+    async ({ page, auth }) => {
+      await setupTest(page, auth, 'private-other');
+
+      const displayedTitle = await page.locator('[data-testid="playlist-title"]').textContent();
+      expect(displayedTitle).toBe('비공개 플레이리스트');
+    },
+  );
+
+  authTest(
+    '삭제된 플레이리스트는 "알 수 없는 플레이리스트"로 표시되어야 한다',
+    async ({ page, auth }) => {
+      const { playlistId } = await setupTest(page, auth, 'deleted');
+
+      const playlistDoc = await getDoc(doc(db, 'playlists', playlistId as string));
+
+      if (!playlistDoc.exists()) {
+        const displayedTitle = await page.locator('[data-testid="playlist-title"]').textContent();
+        expect(displayedTitle).toBe('알 수 없는 플레이리스트');
+      } else {
+        console.log('삭제된 플레이리스트를 시뮬레이션하기 위한 데이터가 없습니다.');
+      }
+    },
+  );
+});
+
+interface SetupTestReturn {
+  postData?: PostModel;
+  playlistId?: string;
+  playlistData?: PlaylistModel;
+}
+
+const setupPublicTest = async (page): Promise<SetupTestReturn> => {
+  const postsCollection = collection(db, 'posts');
+  const postsSnapshot = await getDocs(postsCollection);
+
+  for (const postDoc of postsSnapshot.docs) {
+    const postData = postDoc.data() as PostModel;
+    const { playlistId } = postData;
+
+    const playlistDoc = await getDoc(doc(db, 'playlists', playlistId));
+    const playlistData = playlistDoc.data() as PlaylistModel;
+
+    if (playlistData && playlistData.isPublic) {
+      await page.goto(`/post/${postDoc.id}`);
+      await page.waitForSelector('[data-testid="playlist-title"]');
+      return { postData, playlistId, playlistData };
+    }
+  }
+
+  throw new Error('공개 플레이리스트를 가진 포스트를 찾을 수 없습니다.');
+};
+
+const setupPrivateOwnTest = async (page, auth): Promise<SetupTestReturn> => {
+  const postsCollection = collection(db, 'posts');
+  const postsSnapshot = await getDocs(query(postsCollection, where('userId', '==', auth.UID)));
+
+  for (const postDoc of postsSnapshot.docs) {
+    const postData = postDoc.data() as PostModel;
+    const { playlistId } = postData;
+
+    const playlistDoc = await getDoc(doc(db, 'playlists', playlistId));
+    const playlistData = playlistDoc.data() as PlaylistModel;
+
+    if (playlistData && !playlistData.isPublic && playlistData.userId === auth.UID) {
+      await page.goto(`/post/${postDoc.id}`);
+      await page.waitForSelector('[data-testid="playlist-title"]');
+      return { playlistData };
+    }
+  }
+
+  throw new Error('본인의 비공개 플레이리스트를 가진 포스트를 찾을 수 없습니다.');
+};
+
+const setupPrivateOtherTest = async (page, auth): Promise<SetupTestReturn> => {
+  const postsCollection = collection(db, 'posts');
+  const postsSnapshot = await getDocs(query(postsCollection, where('userId', '!=', auth.UID)));
+
+  for (const postDoc of postsSnapshot.docs) {
+    const postData = postDoc.data() as PostModel;
+    const { playlistId } = postData;
+
+    const playlistDoc = await getDoc(doc(db, 'playlists', playlistId));
+    const playlistData = playlistDoc.data() as PlaylistModel;
+
+    if (playlistData && !playlistData.isPublic && playlistData.userId !== auth.UID) {
+      await page.goto(`/post/${postDoc.id}`);
+      await page.waitForSelector('[data-testid="playlist-title"]');
+      return { playlistData };
+    }
+  }
+
+  throw new Error('타인의 비공개 플레이리스트를 가진 포스트를 찾을 수 없습니다.');
+};
+
+const setupDeletedTest = async (page): Promise<SetupTestReturn> => {
+  try {
+    const { postId, postData } = await findDeletedPlaylistPost();
+    await page.goto(`/post/${postId}`);
+    return { postData, playlistId: postData.playlistId };
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+const findDeletedPlaylistPost = async () => {
+  const postsCollection = collection(db, 'posts');
+  const playlistsCollection = collection(db, 'playlists');
+
+  const postsSnapshot = await getDocs(postsCollection);
+
+  for (const postDoc of postsSnapshot.docs) {
+    const postData = postDoc.data() as PostModel;
+    const { playlistId } = postData;
+
+    const playlistDoc = await getDoc(doc(playlistsCollection, playlistId));
+
+    if (!playlistDoc.exists()) {
+      return { postId: postDoc.id, postData };
+    }
+  }
+
+  throw new Error('삭제된 플레이리스트를 가진 포스트를 찾을 수 없습니다.');
+};
+
+const setupTest = async (
+  page,
+  auth,
+  condition: 'public' | 'private-own' | 'private-other' | 'deleted',
+) => {
+  switch (condition) {
+    case 'public':
+      return await setupPublicTest(page);
+    case 'private-own':
+      return await setupPrivateOwnTest(page, auth);
+    case 'private-other':
+      return await setupPrivateOtherTest(page, auth);
+    case 'deleted':
+      return await setupDeletedTest(page);
+    default:
+      throw new Error(`유효하지 않은 조건: ${condition}`);
+  }
+};


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- AI에게 리뷰를 받고 싶지 않다면 🤷‍♀️이모지를 제거해주세요. -->
@coderabbitai: i🤷‍♀️gnore

## 📋 작업 내용

포스트에 플레이리스트 제목이 제대로 뜨는지 테스트코드 추가
(env에서 REACT_APP_UID를 본인 userId로 바꿔야 본인 기준으로 테스트 가능!)

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/9d9d8458-827d-459d-8b23-8a117728df94)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
### Release Notes

- **Test**: Added `data-testid` attribute to the playlist title span element for improved UI testing.
- **Chore**: Updated Firebase configuration setup in `auth.setup.ts` to load environment variables using dotenv and initialize Firebase app, Firestore, and Auth.
- **Test**: Modified test cases in `playlistTitle.spec.ts` to align with updated function signatures.

These changes enhance testing capabilities and ensure proper Firebase initialization for development and testing environments.
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->