### PR TITLE
[Enhancement] Input 값 최대 길이 설정

### DIFF
--- a/src/components/comment/CommentInput.tsx
+++ b/src/components/comment/CommentInput.tsx
@@ -3,10 +3,12 @@ import { useEffect, useRef } from 'react';
 import { css, SerializedStyles } from '@emotion/react';
 import { HiOutlinePaperAirplane } from 'react-icons/hi2';
 
+import InputCount from '@/components/common/inputs/InputCount';
 import theme from '@/styles/theme';
 
 const INPUT_MIN_HEIGHT = 40;
 const INPUT_MAX_HEIGHT = INPUT_MIN_HEIGHT * 2;
+const MAX_LENGTH = 300;
 
 interface CommentInputProps {
   comment: string;
@@ -17,7 +19,7 @@ interface CommentInputProps {
   handleCompositionEnd: () => void;
 }
 
-export const CommentInput: React.FC<CommentInputProps> = ({
+const CommentInput: React.FC<CommentInputProps> = ({
   comment,
   onChange,
   onSubmit,
@@ -42,18 +44,34 @@ export const CommentInput: React.FC<CommentInputProps> = ({
     }
   };
 
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const inputValue = e.target.value.slice(0, MAX_LENGTH);
+    onChange(inputValue);
+  };
+
   return (
     <div css={[newCommentStyle, customStyle]}>
-      <textarea
-        ref={textareaRef}
-        value={comment}
-        onChange={(e) => onChange(e.target.value)}
-        onKeyDown={handleKeyDown}
-        placeholder="댓글을 작성해주세요"
-        onCompositionStart={handleCompositionStart}
-        onCompositionEnd={handleCompositionEnd}
-        data-testid="comment-input"
-      />
+      <div className="textarea-container">
+        <textarea
+          ref={textareaRef}
+          value={comment}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          placeholder="댓글을 작성해주세요"
+          onCompositionStart={handleCompositionStart}
+          onCompositionEnd={handleCompositionEnd}
+          data-testid="comment-input"
+          maxLength={MAX_LENGTH}
+        />
+        {comment.length > 0 && (
+          <InputCount
+            currentLength={comment.length}
+            maxLength={MAX_LENGTH}
+            customStyle={countStyle}
+          />
+        )}
+      </div>
+
       <button onClick={onSubmit}>
         <HiOutlinePaperAirplane />
       </button>
@@ -69,7 +87,15 @@ const newCommentStyle = css`
   border-radius: 12px;
   background-color: ${theme.colors.bgGray};
 
+  .textarea-container {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    width: 100%;
+  }
+
   textarea {
+    flex-grow: 1;
     width: 100%;
     min-height: ${INPUT_MIN_HEIGHT}px;
     max-height: ${INPUT_MAX_HEIGHT}px;
@@ -83,6 +109,7 @@ const newCommentStyle = css`
     display: flex;
     align-items: center;
     justify-content: center;
+    flex-shrink: 0;
     padding: 8px 10px 12px;
     border: none;
     border-radius: 4px;
@@ -97,3 +124,10 @@ const newCommentStyle = css`
     }
   }
 `;
+
+const countStyle = css`
+  padding: 2px 0 8px;
+  text-align: right;
+`;
+
+export default CommentInput;

--- a/src/components/comment/CommentItem.tsx
+++ b/src/components/comment/CommentItem.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-icons/hi2';
 import { Link } from 'react-router-dom';
 
-import { CommentInput } from '@/components/comment/CommentInput';
+import CommentInput from '@/components/comment/CommentInput';
 import Avatar from '@/components/common/Avatar';
 import FitButton from '@/components/common/buttons/FitButton';
 import OptionModal from '@/components/common/modals/OptionModal';

--- a/src/components/comment/CommentSection.tsx
+++ b/src/components/comment/CommentSection.tsx
@@ -2,14 +2,13 @@ import { css } from '@emotion/react';
 import { HiOutlineChatBubbleOvalLeft } from 'react-icons/hi2';
 
 import defaultProfile from '@/assets/images/default-avatar.svg';
+import CommentInput from '@/components/comment/CommentInput';
+import CommentItem from '@/components/comment/CommentItem';
 import Avatar from '@/components/common/Avatar';
 import EmptyMessage from '@/components/EmptyMessage';
 import { useComments } from '@/hooks/useComments';
 import { useMultipleUsersData } from '@/hooks/useMultipleUsersData';
 import { useUserData } from '@/hooks/useUserData';
-
-import { CommentInput } from './CommentInput';
-import CommentItem from './CommentItem';
 
 interface CommentSectionProps {
   postId: string;

--- a/src/components/common/inputs/BaseInput.tsx
+++ b/src/components/common/inputs/BaseInput.tsx
@@ -1,7 +1,8 @@
 import { ChangeEvent, ReactNode } from 'react';
 
-import { SerializedStyles } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
 
+import InputCount from '@/components/common/inputs/InputCount';
 import { commonInputContainerStyle, errorMessageStyle } from '@/styles/input';
 
 export interface CommonInputProps {
@@ -11,28 +12,49 @@ export interface CommonInputProps {
   label?: string;
   placeholder?: string;
   errorMessage?: string | null;
+  maxLength?: number;
   customStyle?: SerializedStyles;
 }
 
 interface BaseInputProps extends Partial<CommonInputProps> {
   children: ReactNode;
+  currentLength?: number;
 }
 
-const BaseInput: React.FC<BaseInputProps> = ({ label, errorMessage = null, id, children }) => {
+const BaseInput: React.FC<BaseInputProps> = ({
+  label,
+  errorMessage = null,
+  id,
+  currentLength,
+  maxLength,
+  children,
+}) => {
   return (
     <label css={commonInputContainerStyle} htmlFor={id}>
       {label && <span className="input-label">{label}</span>}
       <div className="input-wrapper">
         {children}
-
-        {errorMessage && (
-          <p className="error" css={errorMessageStyle}>
-            {errorMessage}
-          </p>
+        {maxLength && typeof currentLength === 'number' && (
+          <InputCount
+            currentLength={currentLength}
+            maxLength={maxLength}
+            customStyle={countStyle}
+          />
         )}
       </div>
+      {errorMessage && (
+        <p className="error" css={errorMessageStyle}>
+          {errorMessage}
+        </p>
+      )}
     </label>
   );
 };
+
+const countStyle = css`
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+`;
 
 export default BaseInput;

--- a/src/components/common/inputs/Input.tsx
+++ b/src/components/common/inputs/Input.tsx
@@ -10,6 +10,7 @@ const Input: React.FC<InputProps> = ({
   id,
   type = 'text',
   value,
+  maxLength = 100,
   onChange,
   placeholder = '',
   customStyle = undefined,
@@ -17,15 +18,27 @@ const Input: React.FC<InputProps> = ({
 }) => {
   const inputId = id || `input-${generateRandomId()}`;
 
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const inputValue = event.target.value.slice(0, maxLength);
+    onChange({
+      ...event,
+      target: {
+        ...event.target,
+        value: inputValue,
+      },
+    });
+  };
+
   return (
-    <BaseInput id={inputId} {...props}>
+    <BaseInput id={inputId} {...props} currentLength={value.length} maxLength={maxLength}>
       <input
         id={inputId}
         type={type}
         placeholder={placeholder}
-        onChange={onChange}
+        onChange={handleChange}
         value={value}
         css={[commonInputStyle, customStyle]}
+        maxLength={maxLength}
       />
     </BaseInput>
   );

--- a/src/components/common/inputs/InputCount.tsx
+++ b/src/components/common/inputs/InputCount.tsx
@@ -1,0 +1,23 @@
+import { css, SerializedStyles } from '@emotion/react';
+
+import theme from '@/styles/theme';
+
+interface InputCountProps {
+  currentLength: number;
+  maxLength: number;
+  customStyle?: SerializedStyles;
+}
+
+const InputCount: React.FC<InputCountProps> = ({ currentLength, maxLength, customStyle }) => {
+  return (
+    <p css={[countStyle, customStyle]}>
+      {currentLength}/{maxLength}
+    </p>
+  );
+};
+
+const countStyle = css`
+  font-size: ${theme.fontSizes.micro};
+`;
+
+export default InputCount;

--- a/src/components/common/inputs/Textarea.tsx
+++ b/src/components/common/inputs/Textarea.tsx
@@ -11,21 +11,34 @@ const Textarea: React.FC<TextareaProps> = ({
   rows = 5,
   value,
   onChange,
+  maxLength,
   placeholder = '',
   customStyle = undefined,
   ...props
 }) => {
   const textareaId = id || `textarea-${generateRandomId()}`;
 
+  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const inputValue = event.target.value.slice(0, maxLength);
+    onChange({
+      ...event,
+      target: {
+        ...event.target,
+        value: inputValue,
+      },
+    });
+  };
+
   return (
-    <BaseInput id={textareaId} {...props}>
+    <BaseInput id={textareaId} {...props} currentLength={value.length} maxLength={maxLength}>
       <textarea
         id={textareaId}
         value={value}
-        onChange={onChange}
+        onChange={handleChange}
         placeholder={placeholder}
         rows={rows}
         css={[commonInputStyle, customStyle]}
+        maxLength={maxLength}
       />
     </BaseInput>
   );

--- a/src/pages/ProfileEdit.tsx
+++ b/src/pages/ProfileEdit.tsx
@@ -108,6 +108,7 @@ const ProfileEditPage: React.FC = () => {
           placeholder="닉네임을 입력해주세요"
           customStyle={inputStyle}
           label="닉네임"
+          maxLength={10}
         />
         <Textarea
           value={bio}
@@ -115,6 +116,7 @@ const ProfileEditPage: React.FC = () => {
           placeholder="소개를 입력해주세요"
           label="소개"
           customStyle={inputStyle}
+          maxLength={150}
         />
       </div>
       <div css={buttonContainerStyle}>

--- a/src/styles/input.ts
+++ b/src/styles/input.ts
@@ -16,6 +16,7 @@ export const commonInputContainerStyle = css`
   }
 
   .input-wrapper {
+    position: relative;
     flex: 1;
   }
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- AI에게 리뷰를 받고 싶지 않다면 🤷‍♀️이모지를 제거해주세요. -->
@coderabbitai: i🤷‍♀️gnore

## 📋 작업 내용

프로필 수정 페이지의 닉네임, bio
포스트 상세 페이지의 댓글 input에 최대 길이를 설정했습니다
최대 길이가 추가된만큼 얼마나 작성했는지 확인할 수 있도록 InputCount 컴포넌트를 추가했습니다

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/e32dde91-627d-4efb-b426-db528b4003cd)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
## Release Notes

### New Feature
- Added character count display and maximum length restriction to comment input fields.
- Introduced `InputCount` component to show the current length of text inputs.

### Bug Fix
- Fixed redundant import issue in `CommentSection.tsx`.

### Refactor
- Changed `CommentInput` to default export for consistency.
- Updated import paths for `CommentInput` and `CommentItem`.

### Style
- Enhanced input container styling with `position: relative;`.

These changes improve user experience by providing immediate feedback on input length and ensuring consistent import practices across components.
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->